### PR TITLE
SOCIALPLAT-386: adding userId to header

### DIFF
--- a/src/nodejs/node_modules/synthetic/index.ts
+++ b/src/nodejs/node_modules/synthetic/index.ts
@@ -87,6 +87,7 @@ const loadUrl = async function (page, url: string, responseCheck: string) {
 };
 
 const checkQuery = async function () {
+  const userId = process.env.GRAPHQL_USERID || "";
   const endpoint = process.env.GRAPHQL_ENDPOINT || "";
   const queryJmespath = process.env.GRAPHQL_JMESPATH || "";
   const query = process.env.GRAPHQL_QUERY || "";
@@ -134,9 +135,15 @@ const checkQuery = async function () {
     });
   };
 
+  let requestHeaders;
+  if(userId) {
+    requestHeaders = { "Content-Type": "application/json", "userId": userId };
+  }else {
+    requestHeaders = { "Content-Type": "application/json" };
+  }
   let requestOptions = {
     body: query,
-    headers: { "Content-Type": "application/json" },
+    headers: requestHeaders,
     hostname: endpoint,
     method: "POST",
     protocol: "https:",


### PR DESCRIPTION
## Goal

Passing in a `userId` in the headers to make auth requests. Each canary will need to pass a `userId` to run queries, or it will default to `1`.

## Todos

-   [x] pushed new zip to dev

## Tickets

-   [https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-386](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-386)
